### PR TITLE
Suppressed warning "argument slices interface"

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 I2C library change log
 ======================
 
+4.0.1
+-----
+
+  * RESOLVED: Suppressed warning "argument 1 of 'i2c_master_async_aux'
+    slices interface preventing analysis of its parallel usage".
+
 4.0.0
 -----
 

--- a/lib_i2c/src/i2c_master_async.xc
+++ b/lib_i2c/src/i2c_master_async.xc
@@ -123,7 +123,10 @@ void i2c_master_async(server interface i2c_master_async_if i[n],
   i2c_master_if i2c_dist[1];
   par {
     i2c_master(i2c_dist, 1, p_scl, p_sda, kbits_per_second);
+// Disable 'slices interface preventing analysis' warning
+#pragma warning disable
     i2c_master_async_aux(i, n, i2c_dist[0], max_transaction_size);
+#pragma warning enable
   }
 }
 


### PR DESCRIPTION
Added a `#pragma warning disable` around the offending call.
Alternatives would be to remove the function `i2c_master_async_aux` and inline it in place.
