### PR TITLE
Remove .clang-format file

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,3 +1,0 @@
-BasedOnStyle: LLVM
-DisableFormat: true
-SortIncludes: false


### PR DESCRIPTION
As the Jenkins pipeline now only runs clang-format checks when a
.clang-format file is present, it is not necessary to have the file simply
to disable it.