### PR TITLE
Mask off all but lowest bit of SDA port sample

### DIFF
--- a/lib_i2c/src/i2c_master.xc
+++ b/lib_i2c/src/i2c_master.xc
@@ -93,7 +93,8 @@ static int inline high_pulse_sample(
   fall_time = fall_time + bit_time;
   tmr when timerafter(fall_time) :> void;
   p_scl <: 0;
-  return sample_value;
+  // Mask off all but lowest bit of input - allows use of bit[0] of multibit port
+  return sample_value & 1;
 }
 
 /** 'Pulse' the clock line high. Timing is done via the fall_time


### PR DESCRIPTION
Mask off all but lowest bit of input from SDA port - allows use of bit[0] of multibit port