### PR TITLE
Fix to I2C timing for repeated START condition

### DIFF
--- a/lib_i2c/src/i2c_master.xc
+++ b/lib_i2c/src/i2c_master.xc
@@ -133,7 +133,7 @@ static void start_bit(
 
   if (!stopped) {
     tmr when timerafter(fall_time + compute_low_period_ticks(kbits_per_second)) :> void;
-    release_clock_and_wait(p_scl, fall_time, compute_bus_off_ticks(kbits_per_second));
+    release_clock_and_wait(p_scl, fall_time + compute_low_period_ticks(kbits_per_second), compute_bus_off_ticks(kbits_per_second));
   }
 
   // Drive SDA low


### PR DESCRIPTION
This fixes a timing problem that Joe Golightly found in the I2C master driver.
Bug documented in bugzilla http://bugzilla/show_bug.cgi?id=18564

If we have a test somewhere then it would be good to run this
(we ought to also fix the test to cover this particular case)