### PR TITLE
Fixes to the i2c_master_checker.py

### DIFF
--- a/tests/expected/ack_test_no_stop.expect
+++ b/tests/expected/ack_test_no_stop.expect
@@ -20,7 +20,7 @@ Sending ack
 Byte received: 0x0
 Speed = \d+ Kbps
 Sending nack
-Start bit received
+Repeated start bit received
 Byte received: 0x62
 Speed = \d+ Kbps
 Master write transaction started, device address=0x31

--- a/tests/expected/ack_test_stop.expect
+++ b/tests/expected/ack_test_stop.expect
@@ -9,6 +9,7 @@ Sending ack
 Byte received: 0xfe
 Speed = \d+ Kbps
 Sending ack
+Stop bit received
 Start bit received
 Byte received: 0xf6
 Speed = \d+ Kbps

--- a/tests/expected/lock_test.expect
+++ b/tests/expected/lock_test.expect
@@ -14,6 +14,7 @@ Sending ack
 Byte received: 0x99
 Speed = \d+ Kbps
 Sending ack
+Stop bit received
 Start bit received
 Byte received: 0x44
 Speed = \d+ Kbps
@@ -22,3 +23,4 @@ Sending ack
 Byte received: 0x88
 Speed = \d+ Kbps
 Sending ack
+Stop bit received

--- a/tests/expected/master_test_no_stop.expect
+++ b/tests/expected/master_test_no_stop.expect
@@ -9,7 +9,7 @@ Sending ack
 Byte received: 0xfe
 Speed = \d+ Kbps
 Sending nack
-Start bit received
+Repeated start bit received
 Byte received: 0x45
 Speed = \d+ Kbps
 Master read transaction started, device address=0x22
@@ -21,7 +21,7 @@ Byte sent
 Speed = \d+ Kbps
 Master sends NACK.
 Waiting for stop/start bit
-Start bit received
+Repeated start bit received
 Byte received: 0x45
 Speed = \d+ Kbps
 Master read transaction started, device address=0x22
@@ -30,7 +30,7 @@ Byte sent
 Speed = \d+ Kbps
 Master sends NACK.
 Waiting for stop/start bit
-Start bit received
+Repeated start bit received
 Byte received: 0xf6
 Speed = \d+ Kbps
 Master write transaction started, device address=0x7b
@@ -44,7 +44,7 @@ Sending ack
 Byte received: 0xaa
 Speed = \d+ Kbps
 Sending nack
-Start bit received
+Repeated start bit received
 Byte received: 0x62
 Speed = \d+ Kbps
 Master write transaction started, device address=0x31

--- a/tests/expected/repeated_start.expect
+++ b/tests/expected/repeated_start.expect
@@ -14,3 +14,4 @@ Sending ack
 Byte received: 0x99
 Speed = \d+ Kbps
 Sending ack
+Stop bit received

--- a/tests/expected/single_port_test_no_stop.expect
+++ b/tests/expected/single_port_test_no_stop.expect
@@ -9,7 +9,7 @@ Sending ack
 Byte received: 0xfe
 Speed = \d+ Kbps
 Sending nack
-Start bit received
+Repeated start bit received
 Byte received: 0xf6
 Speed = \d+ Kbps
 Master write transaction started, device address=0x7b
@@ -23,7 +23,7 @@ Sending ack
 Byte received: 0xaa
 Speed = \d+ Kbps
 Sending nack
-Start bit received
+Repeated start bit received
 Byte received: 0x45
 Speed = \d+ Kbps
 Master read transaction started, device address=0x22
@@ -35,7 +35,7 @@ Byte sent
 Speed = \d+ Kbps
 Master sends NACK.
 Waiting for stop/start bit
-Start bit received
+Repeated start bit received
 Byte received: 0x11
 Speed = \d+ Kbps
 Master read transaction started, device address=0x8
@@ -50,7 +50,7 @@ Byte sent
 Speed = \d+ Kbps
 Master sends NACK.
 Waiting for stop/start bit
-Start bit received
+Repeated start bit received
 Byte received: 0x62
 Speed = \d+ Kbps
 Master write transaction started, device address=0x31

--- a/tests/expected/single_port_test_stop.expect
+++ b/tests/expected/single_port_test_stop.expect
@@ -62,6 +62,7 @@ Sending ack
 Byte received: 0xee
 Speed = \d+ Kbps
 Sending ack
+Stop bit received
 xCORE got nack, 2
 xCORE got nack, 3
 xCORE got ack

--- a/tests/test_master_clock_stretch.py
+++ b/tests/test_master_clock_stretch.py
@@ -6,6 +6,7 @@ import pytest
 import json
 from i2c_master_checker import I2CMasterChecker
 
+DEBUG = False
 test_name = "i2c_master_test"
 
 with open(Path(__file__).parent / f"{test_name}/test_params.json") as f:
@@ -27,11 +28,13 @@ def test_master_clock_stretch(capfd, request, nightly, dir, speed, stop, arch):
                                tx_data = [0x99, 0x3A, 0xff],
                                expected_speed=170,
                                clock_stretch=5000,
-                               ack_sequence=[True, True, False,
-                                             True,
-                                             True,
-                                             True, True, True, False,
-                                             True, False])
+                               ack_sequence=[True, True, False, # Master write
+                                             True, # Master read
+                                             True, # Master read
+                                             True, True, True, False, # Master write
+                                             True, False], # Master write
+                               #original_speed = speed
+                               )
 
     tester = Pyxsim.testers.AssertiveComparisonTester(
         f'{cwd}/expected/master_test_{stop}.expect',
@@ -40,11 +43,27 @@ def test_master_clock_stretch(capfd, request, nightly, dir, speed, stop, arch):
         suppress_multidrive_messages=True,
     )
 
-    Pyxsim.run_on_simulator_(
-        binary,
-        tester = tester,
-        do_xe_prebuild = False,
-        simthreads = [checker],
-        simargs=['--weak-external-drive'],
-        capfd=capfd
-        )
+    if DEBUG:
+        with capfd.disabled():
+            Pyxsim.run_on_simulator_(
+                binary,
+                tester = tester,
+                do_xe_prebuild = False,
+                simthreads=[checker],
+                simargs=[
+                    "--vcd-tracing",
+                    f"-o i2c_trace.vcd -tile tile[0] -cycles -ports -ports-detailed -cores -instructions",
+                    "--trace-to",
+                    f"i2c_trace.txt",
+                    '--weak-external-drive'
+                ],
+            )
+    else:
+        Pyxsim.run_on_simulator_(
+            binary,
+            tester = tester,
+            do_xe_prebuild = False,
+            simthreads = [checker],
+            simargs=['--weak-external-drive'],
+            capfd=capfd
+            )


### PR DESCRIPTION
Changes in this PR -

- Have NACKED state follow the same path as ACKED. In the current checker, on receiving or sending a NACK, the checker transitions to NACKED_SELECT -> STOPPING_0 -> STOPPING_1 states where it expects a stop or stop/start from the master. I removed these 'artificial' stop states and instead changed NACKED to follow the same path as ACKED, where stop/start/repeated_start conditions are detected through changes in SCL and SDA (in the CHECK_START_STOP state). This makes the code simpler, also more intuitive since the state transitions now follow changes in SCL and SDA.

- Related to above, I also noticed that when stopping through the  NACKED_SELECT -> STOPPING_0 -> STOPPING_1 states, repeated start wasn't being detected. After having NACKED follow the same path as ACKED, repeated start is being detected fine, as part of the CHECK_START_STOP state. As a result, all the no_stop_<something>.expect files now have 'Repeated start bit received' instead of 'Start bit received' which is correct since in the 'no_stop' tests the master sends a start without sending a stop bit (repeated start), so the checker should detect and log a repeated start.

- I also noticed that the setup/hold time check functions (check_hold_start_time, check_setup_start_time etc.) execute the check only for 'speed == 100 or speed == 400'. However, in cases where the slave is clock stretching, the speed detected in the checker is not the same as the speed the master is running at. As a result, the checks don't run at all, leading us to not detect the start bit setup timing violation during repeated start when slave is clock stretching case (test case test_master_clock_stretch.py), as pointed by @QuinnWang in https://github.com/xmos/lib_i2c/pull/83. To fix this, I've added an additional parameter called original_speed which is the speed at which the I2C master is running at (and not the speed detected in the checker). This parameter can be optionally set in the test, otherwise, it's same as the expected speed. I've changed the timing checks to run using the original_speed parameter. test_master_clock_stretch.py is not currently setting the original_speed. However, if it does, the start bit setup timing would get violated in the test. I'll make a PR to fix that next.